### PR TITLE
asw: change g0/5 (rpi) to trunk (dn42&vlan10)

### DIFF
--- a/configs/2960-usman-lan.yml
+++ b/configs/2960-usman-lan.yml
@@ -58,9 +58,10 @@ devices:
       state: "present"
       desc: "Raspberry-Pi-DN42/ns1/blog"
       routed: False
-      mode: "access"
-      access_vlan: "42"
-      spanning_tree: "portfast"
+      mode: "trunk"
+      native_vlan: "10"
+      allowed_vlans: 10, 42
+      spanning_tree: "portfast trunk"
 
     - name: "g 0/6"
       state: "present"


### PR DESCRIPTION
make asw: g0/5 a trunk port with a native vlan of 10, so that the raspberry pi doesn't need to use the USB adapter for the DN42 network.